### PR TITLE
Additional database seeding fixes

### DIFF
--- a/models/Product.js
+++ b/models/Product.js
@@ -1,4 +1,4 @@
-const {Model, DataTypes} = require('sequelize');
+const { Model, DataTypes } = require('sequelize');
 const sequelize = require('../config/connection');
 
 class Product extends Model {}
@@ -23,7 +23,7 @@ Product.init(
       },
     },
     price: {
-      type: DataTypes.DECIMAL,
+      type: DataTypes.DECIMAL(10, 2),
       allowNull: false,
       validate: {
         isDecimal: true,
@@ -50,7 +50,7 @@ Product.init(
     sequelize,
     timestamps: false,
     freezeTableName: true,
-    underscored: true,  
+    underscored: true,
     modelName: 'product',
   }
 );

--- a/seeds/userSeeds.js
+++ b/seeds/userSeeds.js
@@ -19,6 +19,9 @@ const userData = [
   }
 ];
 
-const seedUsers = () => User.bulkCreate(userData);
+const seedUsers = () => User.bulkCreate(userData ,{
+  individualHooks: true,
+  returning: true
+});
 
 module.exports = seedUsers;


### PR DESCRIPTION
The user passwords were not being hashed because I didn't add `individualHooks: true` to the `seedUsers` function so I fixed that.

The prices in the `products` table were being rounded to the nearest whole number. I needed to adjust the DECIMAL data types (see [sequelize number data type docs](https://sequelize.org/docs/v6/core-concepts/model-basics/#numbers)).