### PR TITLE
Styling changes

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -35,6 +35,10 @@
     box-shadow: 2px 2px 2px 2px lightgray;
 }
 
+.card2 {
+  box-shadow: 2px 2px 2px 2px lightgray;
+}
+
 h5 {
   color: black;
 }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -114,7 +114,7 @@
           {{!--------------------------------------------------------------------------------------------------------------}}
           <form class="d-flex search-form " role="search">
             <input class="form-control me-2" id="search" type="search" placeholder="Search" aria-label="Search">
-            <button class="btn btn-outline-success" id="srchBTN" style="color: darkblue; border-color: darkblue;" type="submit"><i class="fa-solid fa-magnifying-glass"></i></button>
+            <button class="btn btn-outline-primary" id="srchBTN" style="color: darkblue; border-color: darkblue;" type="submit"><i class="fa-solid fa-magnifying-glass"></i></button>
           </form>
         </div>
       </div>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -52,7 +52,7 @@
         <div class="float-start">
           <button type="button" class="btn mx-2"  style="color: darkblue;" data-bs-toggle="modal" data-bs-target="#exampleModal">
             <i class="fa-solid fa-circle-plus"></i>
-            Add New Product
+            <strong>Add New Product</strong>
           </button>
           </div>
 

--- a/views/products.handlebars
+++ b/views/products.handlebars
@@ -3,7 +3,7 @@
 	<div class="col-4 m-2 px-0 mx-2" style="width: 16rem;">
 		{{!-- <a class="link text-decoration-none" href="/products/{{id}}"> --}}
 			<div class="card card1" style="border-color: lightgray; border-width: 0.10rem; border-radius: 0.75rem;">
-				<img src="{{product_image_200}}" class="card-img-top p-4" alt="image of {{product_name}}">
+				<img src="{{product_image_300}}" class="card-img-top p-4" alt="image of {{product_name}}">
 				<div class="card-body" style="height: 4.25rem; background-color: white;">
 					<h5 class="card-title text-center">{{product_name}}</h5>
 				</div>
@@ -12,8 +12,8 @@
 					<li class="list-group-item" style="border-color: white;">Stock: {{stock}}</li>
 					<div>
 						<button type="button" class="btn btn-sm mb-3"
-							style="padding: 0.25rem 3rem; color: white; background-color: darkblue; border-radius: 1rem;"
-							onclick="window.location.href='/products/{{id}}';">Details</button>
+							style="padding: 0.5rem 3rem; color: white; background-color: darkblue; border-radius: 1.5rem;"
+							onclick="window.location.href='/products/{{id}}';"><strong>Details</strong></button>
 					</div>
 				</ul>
 			</div>

--- a/views/products.handlebars
+++ b/views/products.handlebars
@@ -1,20 +1,22 @@
 <div class="row" style="justify-content: center;">
-{{#each products as |product|}}
-<div class="col-4 mb-3 card1 px-0 mx-2" style="width: 16rem;">
-	{{!-- <a class="link text-decoration-none" href="/products/{{id}}"> --}}
-	<div class="card" style="border-color: lightgray; border-width: 1.5px; border-radius: 8px;">
-  <img src="{{product_image_200}}" class="card-img-top" alt="image of {{product_name}}">
-  <div class="card-body" style="height: 75px; background-color: white;">
-    <h5 class="card-title text-center">{{product_name}}</h5>
-  </div>
-  <ul class="list-group list-group-flush text-center"  style="border-color: white;">
-    <li class="list-group-item" style="border-color: white;">${{price}}</li>
-    <li class="list-group-item" style="border-color: white;">Stock: {{stock}}</li>
-	<div>
-	<button type="button" class="btn btn-sm mb-3" style="padding: 3px 75px; color: white; background-color: darkblue; border-radius: 25px;" onclick="window.location.href='/products/{{id}}';">Details</button>
- </div>
-  </ul>
-  </div>
-</div>
-{{/each}}
+	{{#each products as |product|}}
+	<div class="col-4 mb-3 px-0 mx-2" style="width: 16rem;">
+		{{!-- <a class="link text-decoration-none" href="/products/{{id}}"> --}}
+			<div class="card card1" style="border-color: lightgray; border-width: 0.10rem; border-radius: 0.75rem;">
+				<img src="{{product_image_200}}" class="card-img-top p-4" alt="image of {{product_name}}">
+				<div class="card-body" style="height: 4.25rem; background-color: white;">
+					<h5 class="card-title text-center">{{product_name}}</h5>
+				</div>
+				<ul class="list-group list-group-flush text-center" style="border-color: white;">
+					<li class="list-group-item" style="border-color: white;">${{price}}</li>
+					<li class="list-group-item" style="border-color: white;">Stock: {{stock}}</li>
+					<div>
+						<button type="button" class="btn btn-sm mb-3"
+							style="padding: 0.25rem 3rem; color: white; background-color: darkblue; border-radius: 1rem;"
+							onclick="window.location.href='/products/{{id}}';">Details</button>
+					</div>
+				</ul>
+			</div>
+	</div>
+	{{/each}}
 </div>

--- a/views/products.handlebars
+++ b/views/products.handlebars
@@ -1,6 +1,6 @@
 <div class="row" style="justify-content: center;">
 	{{#each products as |product|}}
-	<div class="col-4 mb-3 px-0 mx-2" style="width: 16rem;">
+	<div class="col-4 m-2 px-0 mx-2" style="width: 16rem;">
 		{{!-- <a class="link text-decoration-none" href="/products/{{id}}"> --}}
 			<div class="card card1" style="border-color: lightgray; border-width: 0.10rem; border-radius: 0.75rem;">
 				<img src="{{product_image_200}}" class="card-img-top p-4" alt="image of {{product_name}}">

--- a/views/singleproduct.handlebars
+++ b/views/singleproduct.handlebars
@@ -1,61 +1,75 @@
-<div class="card1 card mb-3 row mx-auto" style="max-width: 1000px; justify-content: center; background-color: white; border-color: lightgray; border-width: 1.5px;">
-  <div class="row g-0">
-    <div class="col-md-4">
-      <img
-        src="{{singleProduct.product_image_400}}"
-        alt="image of {{singleProdcut.product_name}}"
-        class="img-fluid rounded-start"
-      />
-    </div>
-    <div class="col-md-8">
-      <div class="card-body text-center">
-        <h5 class="card-title fs-1">{{singleProduct.product_name}}</h5>
+<div class="card2 card mb-3 row mx-auto"
+	style="max-width: 1000px; justify-content: center; background-color: white; border-color: lightgray; border-width: 1.5px;">
+	<div class="row g-0">
+		<div class="col-md-4">
+			<img src="{{singleProduct.product_image_400}}" alt="image of {{singleProdcut.product_name}}"
+				class="img-fluid rounded-start" />
 		</div>
-		  <ul class="list-group list-group-flush text-center row mx-auto fs-2" style="max-width: 300px; justify-content: center; border-radius: 10px;">
-    <li class="list-group-item" style=" border-color: white; background-color: white;">${{singleProduct.price}}</li>
-    <li class="list-group-item" style=" border-color: white; background-color: white;">Stock: {{singleProduct.stock}}</li>
-	<br>
-  </ul>
-  <div class="text-center">
-	<button class="btn btn-danger float-center deleteProduct" style="background-color: red; color: white; padding: 3px 35px; border-radius: 25px;" type="submit">Delete Product<i class="fa-solid fa-trash" id="singleprodIcon"></i></button>
-	{{!---------------------------------------------------------------------------------------------}}
-	<button type="button" class="btn" style="background-color: darkblue; color: white; padding: 3px 40px; border-radius: 25px;" data-bs-toggle="modal" data-bs-target="#editModal">
-		Edit Product<i class="fa-solid fa-pen-to-square" id="singleprodIcon"></i>
-	</button>
-
-	<!-- Modal -->
-	<div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModal" aria-hidden="true">
-		<div class="modal-dialog">
-			<div class="modal-content">
-				<div class="modal-header">
-					<h1 class="modal-title fs-5" id="editModal">Edit Product</h1>
-					<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+		<div class="col-md-8">
+			<div class="card-body text-center">
+				<h5 class="card-title fs-1">{{singleProduct.product_name}}</h5>
+			</div>
+			<ul class="list-group list-group-flush text-center row mx-auto fs-2"
+				style="max-width: 300px; justify-content: center; border-radius: 10px;">
+				<li class="list-group-item" style=" border-color: white; background-color: white;">
+					${{singleProduct.price}}</li>
+				<li class="list-group-item" style=" border-color: white; background-color: white;">Stock:
+					{{singleProduct.stock}}</li>
+				<br>
+			</ul>
+			<div class="text-center">
+				<div style="display: inline-block" class="pb-2">
+					<button type="button" class="btn"
+						style="background-color: darkblue; color: white; width:12em; padding: 0.25rem; border-radius: 1.5rem;"
+						data-bs-toggle="modal" data-bs-target="#editModal">
+						Edit Product<i class="fa-solid fa-pen-to-square" id="singleprodIcon"></i>
+					</button>
 				</div>
-				<div class="modal-body">
-					<div class="form-outline mb-3">
-						<label class="form-label float-start" for="">Product Name</label>
-						<input type="text" id="pName" class="form-control form-control-lg" value="{{singleProduct.product_name}}" />
-					</div>
-
-					<div class="form-outline mb-3">
-						<label class="form-label float-start" for="">Product Price</label>
-						<input type="text" id="pPrice" class="form-control form-control-lg" value="{{singleProduct.price}}" />
-					</div>
-
-					<div class="form-outline mb-3">
-						<label class="form-label float-start" for="">Product Stock</label>
-						<input type="text" id="pStock" class="form-control form-control-lg" value="{{singleProduct.stock}}" />
-
-					</div>
+				{{!---------------------------------------------------------------------------------------------}}
+				<div style="display: inline-block" class="pb-2">
+					<button class="btn btn-danger float-center deleteProduct"
+						style="background-color: red; color: white; width: 12em; padding: 0.25rem; border-radius: 1.5rem;"
+						type="submit">Delete Product<i class="fa-solid fa-trash" id="singleprodIcon"></i>
+					</button>
 				</div>
-				<div class="modal-footer">
-					<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-					<button type="button" id="editConfirm" class="btn btn-primary">Confirm</button>
+				{{!---------------------------------------------------------------------------------------------}}
+				<!-- Modal -->
+				<div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModal" aria-hidden="true">
+					<div class="modal-dialog">
+						<div class="modal-content">
+							<div class="modal-header">
+								<h1 class="modal-title fs-5" id="editModal">Edit Product</h1>
+								<button type="button" class="btn-close" data-bs-dismiss="modal"
+									aria-label="Close"></button>
+							</div>
+							<div class="modal-body">
+								<div class="form-outline mb-3">
+									<label class="form-label float-start" for="">Product Name</label>
+									<input type="text" id="pName" class="form-control form-control-lg"
+										value="{{singleProduct.product_name}}" />
+								</div>
+
+								<div class="form-outline mb-3">
+									<label class="form-label float-start" for="">Product Price</label>
+									<input type="text" id="pPrice" class="form-control form-control-lg"
+										value="{{singleProduct.price}}" />
+								</div>
+
+								<div class="form-outline mb-3">
+									<label class="form-label float-start" for="">Product Stock</label>
+									<input type="text" id="pStock" class="form-control form-control-lg"
+										value="{{singleProduct.stock}}" />
+
+								</div>
+							</div>
+							<div class="modal-footer">
+								<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+								<button type="button" id="editConfirm" class="btn btn-primary">Confirm</button>
+							</div>
+						</div>
+					</div>
+					</form>
 				</div>
 			</div>
 		</div>
-		</form>
 	</div>
-      </div>
-    </div>
-  </div>

--- a/views/singleproduct.handlebars
+++ b/views/singleproduct.handlebars
@@ -1,9 +1,9 @@
-<div class="card2 card mb-3 row mx-auto"
+<div class="card2 card m-3 pb-3 row mx-auto"
 	style="max-width: 1000px; justify-content: center; background-color: white; border-color: lightgray; border-width: 1.5px;">
 	<div class="row g-0">
 		<div class="col-md-4">
-			<img src="{{singleProduct.product_image_400}}" alt="image of {{singleProdcut.product_name}}"
-				class="img-fluid rounded-start" />
+			<img src="{{singleProduct.product_image_500}}" alt="image of {{singleProdcut.product_name}}"
+				class="img-fluid rounded-start p-3" />
 		</div>
 		<div class="col-md-8">
 			<div class="card-body text-center">
@@ -18,18 +18,18 @@
 				<br>
 			</ul>
 			<div class="text-center">
-				<div style="display: inline-block" class="pb-2">
+				<div style="display: inline-block" class="p-1">
 					<button type="button" class="btn"
-						style="background-color: darkblue; color: white; width:12em; padding: 0.25rem; border-radius: 1.5rem;"
+						style="background-color: darkblue; color: white; width:13em; padding: 0.5rem; border-radius: 1.5rem;"
 						data-bs-toggle="modal" data-bs-target="#editModal">
-						Edit Product<i class="fa-solid fa-pen-to-square" id="singleprodIcon"></i>
+						<strong>Edit Product</strong><i class="fa-solid fa-pen-to-square" id="singleprodIcon"></i>
 					</button>
 				</div>
 				{{!---------------------------------------------------------------------------------------------}}
-				<div style="display: inline-block" class="pb-2">
+				<div style="display: inline-block" class="p-1">
 					<button class="btn btn-danger float-center deleteProduct"
-						style="background-color: red; color: white; width: 12em; padding: 0.25rem; border-radius: 1.5rem;"
-						type="submit">Delete Product<i class="fa-solid fa-trash" id="singleprodIcon"></i>
+						style="background-color: red; color: white; width: 13em; padding: 0.5rem; border-radius: 1.5rem;"
+						type="submit"><strong>Delete Product</strong><i class="fa-solid fa-trash" id="singleprodIcon"></i>
 					</button>
 				</div>
 				{{!---------------------------------------------------------------------------------------------}}
@@ -50,13 +50,13 @@
 								</div>
 
 								<div class="form-outline mb-3">
-									<label class="form-label float-start" for="">Product Price</label>
+									<label class="form-label float-start" for="">Price</label>
 									<input type="text" id="pPrice" class="form-control form-control-lg"
 										value="{{singleProduct.price}}" />
 								</div>
 
 								<div class="form-outline mb-3">
-									<label class="form-label float-start" for="">Product Stock</label>
+									<label class="form-label float-start" for="">Stock</label>
 									<input type="text" id="pStock" class="form-control form-control-lg"
 										value="{{singleProduct.stock}}" />
 

--- a/views/singleproduct.handlebars
+++ b/views/singleproduct.handlebars
@@ -1,4 +1,4 @@
-<div class="card2 card m-3 pb-3 row mx-auto"
+<div class="card2 card m-3 pb-1 row mx-auto"
 	style="max-width: 1000px; justify-content: center; background-color: white; border-color: lightgray; border-width: 1.5px;">
 	<div class="row g-0">
 		<div class="col-md-4">


### PR DESCRIPTION
## Change Description
### Products view
- The box-shadow on hover was fixed so that it respects the border radius of the card (no longer looks wonky). 
- The product card margin was changed so that the card doesn't touch the top of the navbar when in a small viewport. 
- Button size was increased so it's easier to hit on mobile. 
- Thumbnail image resolution was increased (no side effects, cards are the same size -- just looks better now). 
- small 
- The Details button font was made bold.

### Singleproducts view
- Some padding was added to images so images don't touch the edge of card.
- The button order was rearranged. It looks better when delete is on the bottom when the viewport is squeezed. 
- The buttons were made the same width for visual consistency. 
- Padding below buttons was added so they don't touch. 
- A permanent box-shadow was added to the card instead of on-hover effect (I don't think it makes sense for a singleproduct view to have a hover effect).
- Image size was increased to the 500px option
- The button fonts were made bold.

**General changes**
- bold 'Add New Product' button

## Before and After Images
### New sigleproducts card
<img width="447" alt="new products card" src="https://user-images.githubusercontent.com/39972418/210494658-7f1d2584-afef-4f4c-8c7e-2bc586e2211e.png">

### Old singleproducts card
<img width="447" alt="old products card" src="https://user-images.githubusercontent.com/39972418/210494846-092e2667-82e0-4bce-81ee-c4b824678bdd.png">

### New products view
<img width="1575" alt="new products view" src="https://user-images.githubusercontent.com/39972418/210495688-a74e580d-af50-4edd-a4a1-6bceb096ac64.png">


### Old products view
<img width="1575" alt="old products view" src="https://user-images.githubusercontent.com/39972418/210495705-53d951be-2f38-4b5f-a00f-0427e31eb6ae.png">


